### PR TITLE
RDKEMW-1649: [Xione-UK]MAINTENANCE Error and RFC logs are not available post Unsolicited Maintanence.

### DIFF
--- a/rfcMgr/rfc_xconf_handler.h
+++ b/rfcMgr/rfc_xconf_handler.h
@@ -115,7 +115,7 @@ class RuntimeFeatureControlProcessor : public xconf::XconfHandler
         bool isRebootRequired;
 	std::string bkup_hash;
         bool _is_first_request;
-        bool _url_validation_in_progress;
+        bool _url_validation_in_progress = false;
         std::string  rfcSelectOpt;
         std:: string rfcSelectorSlot;
 		 


### PR DESCRIPTION
Observed that "_url_validation_in_progress" is set to true and hence when we receive http code = 304, Which Returns Success value.

Since the response 304, its not a valid json and hence ProcessJsonResponse Failed.