### PR TITLE
RDK-55340:[RDK-E] Secure unlock of Platform Services - RFC Settings

### DIFF
--- a/rfcMgr/rfc_xconf_handler.cpp
+++ b/rfcMgr/rfc_xconf_handler.cpp
@@ -39,13 +39,14 @@ extern "C" {
 int RuntimeFeatureControlProcessor:: InitializeRuntimeFeatureControlProcessor(void)
 {
      std::string rfc_file;
+     bool dbgServices = isDebugServicesEnabled();
 	
      if(0 != initializeXconfHandler())
      {
 	return FAILURE;
      }
     
-    if((filePresentCheck(RFC_PROPERTIES_PERSISTENCE_FILE) == RDK_API_SUCCESS) && (_ebuild_type != ePROD))
+    if((filePresentCheck(RFC_PROPERTIES_PERSISTENCE_FILE) == RDK_API_SUCCESS) && (_ebuild_type != ePROD || dbgServices == true))
     {
 	rfc_file = RFC_PROPERTIES_PERSISTENCE_FILE;
     }
@@ -112,6 +113,24 @@ bool RuntimeFeatureControlProcessor::checkWhoamiSupport( )
     return found;
 }
 
+bool RuntimeFeatureControlProcessor::isDebugServicesEnabled(void)
+{
+    bool result = false;
+    int ret = -1;
+    char rfc_data[RFC_VALUE_BUF_SIZE];
+
+    *rfc_data = 0;
+    ret = read_RFCProperty("DEBUGSRV", RFC_DEBUGSRV, rfc_data, sizeof(rfc_data));
+    if (ret == -1) {
+        SWLOG_ERROR("%s: rfc Debug services =%s failed Status %d\n", __FUNCTION__, RFC_DEBUGSRV, ret);
+    } else {
+        SWLOG_INFO("%s: rfc Debug services = %s\n", __FUNCTION__, rfc_data);
+        if (strncmp(rfc_data, "true", sizeof(rfc_data)+1 ) == 0) {
+            result = true;
+        }
+    }
+    return result;
+}
 
 
 bool RuntimeFeatureControlProcessor::IsNewFirmwareFirstRequest(void)

--- a/rfcMgr/rfc_xconf_handler.cpp
+++ b/rfcMgr/rfc_xconf_handler.cpp
@@ -62,7 +62,7 @@ int RuntimeFeatureControlProcessor:: InitializeRuntimeFeatureControlProcessor(vo
         return FAILURE;
     }
 
-    rfc_state = (_ebuild_type != ePROD) ? Local : Init;
+    rfc_state = (_ebuild_type != ePROD || dbgServices == true) ? Local : Init;
 
     /* get experience */ 
     if(-1 == GetExperience())
@@ -618,12 +618,13 @@ int RuntimeFeatureControlProcessor::ProcessRuntimeFeatureControlReq()
     int result = FAILURE;
 
     bool skip_direct = IsDirectBlocked();
+    bool dbgServices = isDebugServicesEnabled();
 
     if(skip_direct == false)
     {
         while(retries < RETRY_COUNT)
         {
-            if((filePresentCheck(RFC_PROPERTIES_PERSISTENCE_FILE) == RDK_API_SUCCESS) && (_ebuild_type != ePROD))
+            if((filePresentCheck(RFC_PROPERTIES_PERSISTENCE_FILE) == RDK_API_SUCCESS) && (_ebuild_type != ePROD || dbgServices == true))
             {
                 RDK_LOG(RDK_LOG_ERROR, LOG_RFCMGR, "[%s][%d] Setting URL to %s from local override\n", __FUNCTION__, __LINE__, _xconf_server_url.c_str());
             }

--- a/rfcMgr/rfc_xconf_handler.h
+++ b/rfcMgr/rfc_xconf_handler.h
@@ -60,6 +60,7 @@ extern "C" {
 #define VARIABLEFILE                       "/opt/secure/RFC/rfcVariable.ini"
 #define TR181LISTFILE                      "/opt/secure/RFC/tr181.list"
 #define DIRECT_BLOCK_FILENAME              "/tmp/.lastdirectfail_rfc"
+#define RFC_DEBUGSRV                       "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Identity.DbgServices.Enable"
 
 #define RFC_VIDEO_CONTROL_ID               2504
 #define RFC_VIDEO_VOD_ID                   15660
@@ -115,7 +116,7 @@ class RuntimeFeatureControlProcessor : public xconf::XconfHandler
         bool isRebootRequired;
 	std::string bkup_hash;
         bool _is_first_request;
-        bool _url_validation_in_progress = false;
+        bool _url_validation_in_progress;
         std::string  rfcSelectOpt;
         std:: string rfcSelectorSlot;
 		 
@@ -168,6 +169,7 @@ class RuntimeFeatureControlProcessor : public xconf::XconfHandler
 	void cleanAllFile();
         int ProcessXconfUrl(const char *XconfUrl);
         void NotifyTelemetry2Count(std ::string markerName);
+	bool isDebugServicesEnabled(void);
 
 #if defined(GTEST_ENABLE)
     FRIEND_TEST(rfcMgrTest, isNewFirmwareFirstRequest);

--- a/rfcMgr/rfc_xconf_handler.h
+++ b/rfcMgr/rfc_xconf_handler.h
@@ -116,7 +116,7 @@ class RuntimeFeatureControlProcessor : public xconf::XconfHandler
         bool isRebootRequired;
 	std::string bkup_hash;
         bool _is_first_request;
-        bool _url_validation_in_progress;
+        bool _url_validation_in_progress = false;
         std::string  rfcSelectOpt;
         std:: string rfcSelectorSlot;
 		 


### PR DESCRIPTION
Reason for change: Integrating rfc debug services changes
Test Procedure: Set debug services and verify
Risks: Low
Priority: P1