### PR TITLE
RDK-57916: Update T2 Event Markers for rfcscript.log (#34)

### DIFF
--- a/rfcMgr/rfc_manager.cpp
+++ b/rfcMgr/rfc_manager.cpp
@@ -344,7 +344,8 @@ namespace rfc {
             bool isRebootRequired = rfcObj->getRebootRequirement();
             if(isRebootRequired == true)
             {
-                RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR,"[%s][%d] RFC: Posting Reboot Required Event to MaintenanceMGR\n", __FUNCTION__,__LINE__);
+                RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR,"[%s][%d] RFC: Posting Reboot Required Event to MaintenanceMGR\n", __FUNCTION__,__LINE__);
+		rfcObj->NotifyTelemetry2Count("SYST_INFO_RFC_Reboot");
                 SendEventToMaintenanceManager("MaintenanceMGR", MAINT_CRITICAL_UPDATE);
                 SendEventToMaintenanceManager("MaintenanceMGR", MAINT_REBOOT_REQUIRED);
             }
@@ -353,6 +354,7 @@ namespace rfc {
         else
         {
             RDK_LOG(RDK_LOG_ERROR, LOG_RFCMGR,"[%s][%d] RFC: Posting RFC Error Event to MaintenanceMGR\n", __FUNCTION__,__LINE__);
+   	    rfcObj->NotifyTelemetry2Count("SYST_INFO_RFC_Error");
             SendEventToMaintenanceManager("MaintenanceMGR", MAINT_RFC_ERROR);
         }
         
@@ -360,6 +362,7 @@ namespace rfc {
 	if(post_process_result == SUCCESS)
 	{
             RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR,"[%s][%d] RFC:Post Processing Successfully Completed\n", __FUNCTION__,__LINE__);
+   	    rfcObj->NotifyTelemetry2Count("SYST_INFO_RFC_PostProcess_Success");
 	}
 	else
 	{

--- a/rfcMgr/rfc_xconf_handler.cpp
+++ b/rfcMgr/rfc_xconf_handler.cpp
@@ -649,7 +649,8 @@ int RuntimeFeatureControlProcessor::ProcessRuntimeFeatureControlReq()
         {
             if((filePresentCheck(RFC_PROPERTIES_PERSISTENCE_FILE) == RDK_API_SUCCESS) && (_ebuild_type != ePROD || dbgServices == true))
             {
-                RDK_LOG(RDK_LOG_ERROR, LOG_RFCMGR, "[%s][%d] Setting URL to %s from local override\n", __FUNCTION__, __LINE__, _xconf_server_url.c_str());
+                RDK_LOG(RDK_LOG_ERROR, LOG_RFCMGR, "[%s][%d] Setting URL from local override to %s\n", __FUNCTION__, __LINE__, _xconf_server_url.c_str());
+                NotifyTelemetry2Value("SYST_INFO_RFC_XconflocalURL", _xconf_server_url.c_str());
             }
             else 
             {
@@ -657,7 +658,8 @@ int RuntimeFeatureControlProcessor::ProcessRuntimeFeatureControlReq()
                 {
                     _xconf_server_url.clear();
                     _xconf_server_url = _boot_strap_xconf_url + "/featureControl/getSettings";
-                    RDK_LOG(RDK_LOG_ERROR, LOG_RFCMGR, "[%s][%d] Setting URL to %s from Bootstrap config XCONF_BS_URL:%s\n", __FUNCTION__, __LINE__, _xconf_server_url.c_str(), _boot_strap_xconf_url.c_str());
+                    RDK_LOG(RDK_LOG_ERROR, LOG_RFCMGR, "[%s][%d] Setting URL from Bootstrap config XCONF_BS_URL:%s to %s \n", __FUNCTION__, __LINE__, _boot_strap_xconf_url.c_str(), _xconf_server_url.c_str());
+                    NotifyTelemetry2Value("SYST_INFO_RFC_XconfBSURL", _xconf_server_url.c_str());
                 }
             }
             std::stringstream url = CreateXconfHTTPUrl();
@@ -711,6 +713,7 @@ int RuntimeFeatureControlProcessor::ProcessRuntimeFeatureControlReq()
                         updateTimeInDB("0");
                     }
                     RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR, "[%s][%d] COMPLETED RFC PASS\n", __FUNCTION__, __LINE__);
+   	            NotifyTelemetry2Count("SYST_INFO_RFC_Complete");
                     set_RFCProperty(XCONF_SELECTOR_NAME, XCONF_SELECTOR_KEY_STR, rfcSelectOpt.c_str());
                     set_RFCProperty(XCONF_URL_TR181_NAME, XCONF_URL_KEY_STR, _xconf_server_url.c_str());
                     
@@ -928,6 +931,9 @@ int RuntimeFeatureControlProcessor::DownloadRuntimeFeatutres(DownloadData *pDwnL
 	    
             switch(curl_ret_code)
             {
+                case  6:
+                case 18:
+                case 28:
                 case 35:
                 case 51:
                 case 53:
@@ -950,6 +956,7 @@ int RuntimeFeatureControlProcessor::DownloadRuntimeFeatutres(DownloadData *pDwnL
             {
 	        cleanAllFile();
 		RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR, "[Features Enabled]-[NONE]:\n");
+		NotifyTelemetry2Count("SYST_INFO_RFC_FeaturesNone");
             }
             else if(httpCode == 304)
             {
@@ -1286,6 +1293,12 @@ void RuntimeFeatureControlProcessor::NotifyTelemetry2Count(std ::string markerNa
     v_secure_system("/usr/bin/telemetry2_0_client %s %d", markerName.c_str(), count);
 }
 
+
+void RuntimeFeatureControlProcessor::NotifyTelemetry2Value(std ::string markerName, std ::string value)
+{
+    v_secure_system("/usr/bin/telemetry2_0_client %s %s", markerName.c_str(), value.c_str());
+}
+
 void RuntimeFeatureControlProcessor::processXconfResponseConfigDataPart(JSON *features)
 {
     CreateConfigDataValueMap(features);
@@ -1515,8 +1528,11 @@ void RuntimeFeatureControlProcessor::NotifyTelemetry2RemoteFeatures(const char *
         RDK_LOG(RDK_LOG_ERROR, LOG_RFCMGR, "[%s][%d] RFC Feature List is not found in the file.\n" , __FUNCTION__, __LINE__);
         return;
     }
-    v_secure_system("/usr/bin/telemetry2_0_client rfc_split %s", line.c_str());
-
+    if (rfcstatus == "STAGING") {
+        v_secure_system("/usr/bin/telemetry2_0_client rfc_staging_split %s", line.c_str());
+    } else {
+        v_secure_system("/usr/bin/telemetry2_0_client rfc_split %s", line.c_str());
+    }
 }
 
 void RuntimeFeatureControlProcessor::WriteFile(const std::string& filename, const std::string& data) 

--- a/rfcMgr/rfc_xconf_handler.h
+++ b/rfcMgr/rfc_xconf_handler.h
@@ -92,7 +92,9 @@ class RuntimeFeatureControlProcessor : public xconf::XconfHandler
         int  InitializeRuntimeFeatureControlProcessor(void);
         int ProcessRuntimeFeatureControlReq();
         bool getRebootRequirement();
-        
+        void NotifyTelemetry2Count(std ::string markerName);
+        void NotifyTelemetry2Value(std ::string markerName, std ::string value);
+
 	private:
 
         typedef struct RuntimeFeatureControlObject {
@@ -169,7 +171,6 @@ class RuntimeFeatureControlProcessor : public xconf::XconfHandler
 	int getJRPCTokenData( char *, char *, unsigned int );
 	void cleanAllFile();
         int ProcessXconfUrl(const char *XconfUrl);
-        void NotifyTelemetry2Count(std ::string markerName);
 	bool isDebugServicesEnabled(void);
 
 #if defined(GTEST_ENABLE)


### PR DESCRIPTION
* RDK-57916: Update T2 Event Markers for rfcscript.log

* Update rfc_xconf_handler.h

* Update rfc_manager.cpp

* Update rfc_xconf_handler.cpp

* Update rfc_xconf_handler.cpp

* Update rfc_manager.cpp

---------