### PR TITLE
DELIA-68312: RFC Lock file not deleted after RFC Configuration complete

### DIFF
--- a/rfcMgr/rfc_main.cpp
+++ b/rfcMgr/rfc_main.cpp
@@ -35,7 +35,7 @@ extern "C" {
 // Cleanup function
 void cleanup_lock_file(void)
 {
-    RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] RFC: Completed service, deleting lock\n", __FUNCTION__, __LINE__);
+    RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR, "[%s][%d] RFC: Completed service, deleting lock\n", __FUNCTION__, __LINE__);
     unlink(RFC_MGR_SERVICE_LOCK_FILE);
 }
 
@@ -68,7 +68,7 @@ int main()
 	
     rfc::RFCManager* rfcMgr = new rfc::RFCManager();
 
-    RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] RFC: Starting service, creating lock \n", __FUNCTION__, __LINE__);
+    RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR, "[%s][%d] RFC: Starting service, creating lock \n", __FUNCTION__, __LINE__);
 	
      /* Abort if another instance of rfcMgr is already running */
     if (CurrentRunningInst(RFC_MGR_SERVICE_LOCK_FILE))
@@ -83,16 +83,16 @@ int main()
     if (isDeviceOnline == rfc::RFCMGR_DEVICE_ONLINE) 
     {
         int status = FAILURE;
-        RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] RFC:Device is Online\n", __FUNCTION__, __LINE__);
+        RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR, "[%s][%d] RFC:Device is Online\n", __FUNCTION__, __LINE__);
         status = rfcMgr->RFCManagerProcessXconfRequest();
         if(status == SUCCESS)
         {
-            RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] RFC:Xconf Request Processed successfully\n", __FUNCTION__, __LINE__);  
+            RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR, "[%s][%d] RFC:Xconf Request Processed successfully\n", __FUNCTION__, __LINE__);  
         }
     }
     else
     {
-        RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] RFC:Device is Offline\n", __FUNCTION__, __LINE__);
+        RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR, "[%s][%d] RFC:Device is Offline\n", __FUNCTION__, __LINE__);
     }
 
 #ifdef INCLUDE_BREAKPAD

--- a/rfcMgr/rfc_main.cpp
+++ b/rfcMgr/rfc_main.cpp
@@ -30,6 +30,22 @@ extern "C" {
 #include "breakpad_wrapper.h"
 #endif
 
+#include <signal.h>
+
+// Cleanup function
+void cleanup_lock_file(void)
+{
+    RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] RFC: Completed service, deleting lock\n", __FUNCTION__, __LINE__);
+    unlink(RFC_MGR_SERVICE_LOCK_FILE);
+}
+
+// Signal handler for graceful shutdown
+void signal_handler(int sig)
+{
+    cleanup_lock_file();
+    exit(0);
+}
+
 int main()
 {
     pid_t pid;
@@ -44,13 +60,20 @@ int main()
     {
         exit(EXIT_SUCCESS);
     }
-    
+    atexit(cleanup_lock_file);
+
+    signal(SIGINT, signal_handler);
+    signal(SIGTERM, signal_handler);	
+	
     rfc::RFCManager* rfcMgr = new rfc::RFCManager();
 
+    RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] RFC: Starting service, creating lock \n", __FUNCTION__, __LINE__);
+	
      /* Abort if another instance of rfcMgr is already running */
     if (CurrentRunningInst(RFC_MGR_SERVICE_LOCK_FILE))
     {
 	rfcMgr->SendEventToMaintenanceManager("MaintenanceMGR", MAINT_RFC_INPROGRESS);
+	RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR, "[%s][%d] RFC: rfcMgr Process in progress, New instance not allowed. Lock file %s is locked!\n", __FUNCTION__, __LINE__, RFC_MGR_SERVICE_LOCK_FILE);
         delete rfcMgr;
         return 1;
     }

--- a/rfcMgr/rfc_main.cpp
+++ b/rfcMgr/rfc_main.cpp
@@ -42,6 +42,7 @@ void cleanup_lock_file(void)
 // Signal handler for graceful shutdown
 void signal_handler(int sig)
 {
+    RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR, "RFC: Received signal %d, cleaning up lock file\n", sig);	
     cleanup_lock_file();
     exit(0);
 }
@@ -73,7 +74,7 @@ int main()
     if (CurrentRunningInst(RFC_MGR_SERVICE_LOCK_FILE))
     {
 	rfcMgr->SendEventToMaintenanceManager("MaintenanceMGR", MAINT_RFC_INPROGRESS);
-	RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR, "[%s][%d] RFC: rfcMgr Process in progress, New instance not allowed. Lock file %s is locked!\n", __FUNCTION__, __LINE__, RFC_MGR_SERVICE_LOCK_FILE);
+	RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR, "[%s][%d] RFC: rfcMgr process in progress, New instance not allowed as file %s is locked!\n", __FUNCTION__, __LINE__, RFC_MGR_SERVICE_LOCK_FILE);
         delete rfcMgr;
         return 1;
     }


### PR DESCRIPTION
DELIA-68312: RFC Lock file not deleted after RFC Configuration complete 


Reason for change: remove lock file after rfc completes
Test Procedure: Build and verify
Risks: Medium
Priority: P0
Signed-off-by: nhanas001c <naveenkumar_hanasi@comcast.com>