### PR TITLE
RDKEMW-5675 [RDKE] onDeviceMgtUpdate sent slightly before RFC processing is complete

### DIFF
--- a/rfcMgr/rfc_xconf_handler.cpp
+++ b/rfcMgr/rfc_xconf_handler.cpp
@@ -495,8 +495,97 @@ bool RuntimeFeatureControlProcessor::isXconfSelectorSlotProd()
     return result;
 }
 
-
 void RuntimeFeatureControlProcessor::clearDB(void)
+{
+
+    // Store permanent parameters before clearing (equivalent to rfcStashStoreParams)	
+    rfcStashStoreParams();	
+    // clear RFC data store before storing new values
+    // this is required as sometime key value pairs will simply
+    // disappear from the config data, as mac is mostly removed
+    // to disable a feature rather than having different value
+    RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] Clearing DB\n", __FUNCTION__,__LINE__);
+    RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] Resetting all rfc values in backing store\n", __FUNCTION__,__LINE__);
+
+#ifndef RDKC
+    std::string name = "rfc";
+    std::string value = "true";
+    std::string ClearDB = "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Control.ClearDB";
+    std::string BootstrapClearDB = "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Bootstrap.Control.ClearDB";
+    std::string ConfigChangeTimeKey = "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Control.ConfigChangeTime";    
+
+    std::time_t timestamp = std::time(nullptr);
+    std::string ConfigChangeTime = std::to_string(timestamp);    
+
+    set_RFCProperty(name, ClearDB, value);
+    set_RFCProperty(name, BootstrapClearDB, value);
+    set_RFCProperty(name, ConfigChangeTimeKey, ConfigChangeTime);
+
+    RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] Clearing DB Value: %s\n", __FUNCTION__,__LINE__,ClearDB.c_str());
+    RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] Bootstrap Clearing DB Value: %s\n", __FUNCTION__,__LINE__,BootstrapClearDB.c_str());
+    RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] ConfigChangeTime: %s\n", __FUNCTION__,__LINE__,ConfigChangeTime.c_str());
+
+    std::ofstream touch_file(TR181STOREFILE);
+    touch_file.close();
+
+#else
+    RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] Clearing tr181 store\n", __FUNCTION__,__LINE__);
+    if (std::remove(TR181STOREFILE) == 0)
+    {
+        RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] File %s removed successfully\n",__FUNCTION__, __LINE__, TR181STOREFILE);
+    }
+#endif
+
+    // Now retrieve parameters that must persist
+    rfcStashRetrieveParams();
+}
+
+void RuntimeFeatureControlProcessor::rfcStashStoreParams(void)
+{
+    // Store parameters that should survive the DB clear
+    // Implementation depends on which parameters need to persist
+    RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] Storing permanent parameters\n", __FUNCTION__, __LINE__);
+
+    // Call existing GetAccountID() to ensure _accountId is populated
+    GetAccountID();
+
+    // Store the current AccountID before clearing DB
+    stashAccountId = _accountId;
+
+    RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] Stashed AccountID: %s\n", __FUNCTION__, __LINE__, stashAccountId.c_str());
+}
+
+void RuntimeFeatureControlProcessor::rfcStashRetrieveParams(void)
+{
+    // Restore the stored permanent parameters
+    // Implementation depends on which parameters need to persist
+    RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] Retrieving permanent parameters\n", __FUNCTION__, __LINE__);
+
+    if (!stashAccountId.empty() && stashAccountId != "Unknown")
+    {
+        RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] Restoring AccountID: %s\n", __FUNCTION__, __LINE__, stashAccountId.c_str());
+
+        std::string name = "rfc";
+
+        WDMP_STATUS status = set_RFCProperty(name, RFC_ACCOUNT_ID_KEY_STR, stashAccountId);
+        if (status != WDMP_SUCCESS)
+        {
+            RDK_LOG(RDK_LOG_ERROR, LOG_RFCMGR, "[%s][%d] Failed to restore AccountID: %s\n", __FUNCTION__, __LINE__, getRFCErrorString(status));
+        }
+        else
+        {
+            RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] Successfully restored AccountID\n", __FUNCTION__, __LINE__);
+            // Update the in-memory copy as well
+            _accountId = stashAccountId;
+        }
+    }
+    else
+    {
+        RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] No valid AccountID to restore\n", __FUNCTION__, __LINE__);
+    }
+}
+
+void RuntimeFeatureControlProcessor::clearDBEnd(void)
 {
     RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] Clearing DB\n", __FUNCTION__,__LINE__);
 
@@ -1367,6 +1456,7 @@ void RuntimeFeatureControlProcessor::processXconfResponseConfigDataPart(JSON *fe
     }
 
     updateTR181File(TR181_FILE_LIST, paramList);
+    clearDBEnd();
 }
 
 void RuntimeFeatureControlProcessor::CreateConfigDataValueMap(JSON *features)

--- a/rfcMgr/rfc_xconf_handler.h
+++ b/rfcMgr/rfc_xconf_handler.h
@@ -59,6 +59,7 @@ extern "C" {
 #define RFC_LAST_VERSION                   "/opt/secure/RFC/.version"
 #define VARIABLEFILE                       "/opt/secure/RFC/rfcVariable.ini"
 #define TR181LISTFILE                      "/opt/secure/RFC/tr181.list"
+#define TR181STOREFILE                      "/opt/secure/RFC/tr181store.ini" 
 #define DIRECT_BLOCK_FILENAME              "/tmp/.lastdirectfail_rfc"
 #define RFC_DEBUGSRV                       "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Identity.DbgServices.Enable"
 
@@ -145,8 +146,12 @@ class RuntimeFeatureControlProcessor : public xconf::XconfHandler
         void updateTimeInDB(std::string timestampString);
         void updateHashAndTimeInDB(char *curlHeaderResp);
         bool IsDirectBlocked();
-        void clearDB();	
-        
+        void clearDB();
+        void clearDBEnd();	
+        void rfcStashStoreParams(void);
+	void RuntimeFeatureControlProcessor::rfcStashRetrieveParams(void);
+
+
         std::stringstream CreateXconfHTTPUrl(); 
         void GetStoredHashAndTime( std ::string &valueHash, std::string &valueTime ); 
         void RetrieveHashAndTimeFromPreviousDataSet(std ::string &valueHash, std::string &valueTime); 

--- a/rfcMgr/rfc_xconf_handler.h
+++ b/rfcMgr/rfc_xconf_handler.h
@@ -109,10 +109,11 @@ class RuntimeFeatureControlProcessor : public xconf::XconfHandler
 	RfcState     rfc_state; /* RFC State */
 	std::string _last_firmware; /* Last Firmware Version */
 	std::string _xconf_server_url; /* Xconf server URL */
-    std::string _boot_strap_xconf_url; /* Bootstrap XConf URL */
+        std::string _boot_strap_xconf_url; /* Bootstrap XConf URL */
 	std::string _valid_accountId; /* Valid Account ID*/
 	std::string _valid_partnerId; /* Valid Partner ID*/
 	std::string _accountId; /* Device Account ID */
+        std::string stashAccountId;
         std::string _partnerId; /* Device Partner ID */
         std::string _bkPartnerId; /* Device Partner ID */
         std::string _experience;
@@ -149,7 +150,7 @@ class RuntimeFeatureControlProcessor : public xconf::XconfHandler
         void clearDB();
         void clearDBEnd();	
         void rfcStashStoreParams(void);
-	void RuntimeFeatureControlProcessor::rfcStashRetrieveParams(void);
+	void rfcStashRetrieveParams(void);
 
 
         std::stringstream CreateXconfHTTPUrl(); 


### PR DESCRIPTION
Modified the changes to add 
Rename the current clearDB() method into clearDBEnd().
Keep the current clearDB() call int the existing position 
Call clearDBEnd() at the end in the processXconfResponseConfigDataPart 

