### PR TITLE
RDK-57302 : Add support for URL Encoding

### DIFF
--- a/rfcMgr/gtest/gtest_main.cpp
+++ b/rfcMgr/gtest/gtest_main.cpp
@@ -515,10 +515,10 @@ TEST(rfcMgrTest, GetValidPartnerId) {
 
 TEST(rfcMgrTest, CreateXconfHTTPUrl) {
     writeToTr181storeFile("WHOAMI_SUPPORT", "true", "/tmp/device.properties", Plain);
-    writeToTr181storeFile("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Bootstrap.OsClass", "TestOsClass", "/opt/secure/RFC/tr181store.ini", Quoted);
+    writeToTr181storeFile("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Bootstrap.OsClass", "TestOs Class", "/opt/secure/RFC/tr181store.ini", Quoted);
     writeToTr181storeFile("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AccountInfo.AccountID", "4123705941507160514", "/opt/secure/RFC/tr181store.ini", Quoted);
     RuntimeFeatureControlProcessor *rfcObj = new RuntimeFeatureControlProcessor();
-    rfcObj->_RFCKeyAndValueMap[RFC_PARNER_ID_KEY_STR] = "sky"; 
+    rfcObj->_RFCKeyAndValueMap[RFC_PARTNER_ID_KEY_STR] = "sky"; 
     rfcObj->_RFCKeyAndValueMap[XCONF_URL_KEY_STR] = "https://xconf.xdp.eu-1.xcal.tv";
     rfcObj->PreProcessJsonResponse(xconfResp);
     rfcObj->GetValidPartnerId();
@@ -526,7 +526,7 @@ TEST(rfcMgrTest, CreateXconfHTTPUrl) {
     rfcObj->GetAccountID();
     rfcObj->GetXconfSelect();
     std:stringstream url = rfcObj->CreateXconfHTTPUrl();
-    EXPECT_EQ(url.str(), "https://xconf.xdp.eu-1.xcal.tv?estbMacAddress=&firmwareVersion=&env=&model=&manufacturer=&controllerId=2504&channelMapId=2345&VodId=15660&partnerId=sky&osClass=TestOsClass&accountId=4123705941507160514&Experience=&version=2");  
+    EXPECT_EQ(url.str(), "https://xconf.xdp.eu-1.xcal.tv?estbMacAddress=&firmwareVersion=&env=&model=&manufacturer=&controllerId=2504&channelMapId=2345&VodId=15660&partnerId=sky&osClass=TestOs%20Class&accountId=4123705941507160514&Experience=&version=2");  
     delete rfcObj;
 }
 

--- a/rfcMgr/gtest/mocks/urlHelper.c
+++ b/rfcMgr/gtest/mocks/urlHelper.c
@@ -930,6 +930,32 @@ bool checkDeviceInternetConnection(long timeout_ms)
     return status;
 }
 
+char* urlEncodeString(const char* inputString)
+{
+    if (!inputString) {
+        SWLOG_ERROR("Input string is NULL in Function %s\n", __FUNCTION__);
+        return NULL;
+    }
+    char* encodedString = NULL;
+    CURL *curl = curl_easy_init();
+    if (curl) 
+    {
+        char *output = curl_easy_escape(curl, inputString, 0);
+        if (output) {
+            encodedString = strdup(output);
+            curl_free(output);
+        } else {
+            SWLOG_ERROR("curl_easy_escape failed in Function %s\n", __FUNCTION__);
+        }
+        curl_easy_cleanup(curl);
+    }
+    else
+    {
+        SWLOG_ERROR("Error in curl_easy_init in Function %s\n", __FUNCTION__);
+    }
+    return encodedString;
+}
+
 // Define your write callback function
 size_t writeFunction(void *contents, size_t size, size_t nmemb, void *userp)
 {

--- a/rfcMgr/gtest/mocks/urlHelper.h
+++ b/rfcMgr/gtest/mocks/urlHelper.h
@@ -134,6 +134,7 @@ int allocDowndLoadDataMem( DownloadData *pDwnData, int szDataSize );
 bool checkDeviceInternetConnection(long);
 size_t writeFunction(void *contents, size_t size, size_t nmemb, void *userp);
 void closeFile(DownloadData *data, struct curlprogress *prog, FILE *fp);
+char* urlEncodeString(const char* inputString);
 #if CURL_DEBUG
 CURLcode setCurlDebugOpt(CURL *curl, DbgData_t *debug);
 #endif

--- a/rfcMgr/rfc_mgr_key.h
+++ b/rfcMgr/rfc_mgr_key.h
@@ -28,7 +28,7 @@
 #define BOOTSTRAP_XCONF_URL_KEY_STR "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Bootstrap.XconfUrl"
 #endif
 #define RFC_ACCOUNT_ID_KEY_STR "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AccountInfo.AccountID"
-#define RFC_PARNER_ID_KEY_STR  "Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.PartnerId"
+#define RFC_PARTNER_ID_KEY_STR  "Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.PartnerId"
 #define RFC_OSCLASS_KEY_STR     "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Bootstrap.OsClass"
 #define RFC_PARTNERNAME_KEY_STR "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Bootstrap.PartnerName"
 #define RFC_CONFIG_SET_HASH    "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Control.ConfigSetHash"

--- a/rfcMgr/rfc_xconf_handler.cpp
+++ b/rfcMgr/rfc_xconf_handler.cpp
@@ -1480,6 +1480,28 @@ int RuntimeFeatureControlProcessor::ProcessRuntimeFeatureControlReq()
     return result;
 }
 
+bool urlencodingInterface(const std::string& input, std::stringstream& output) {
+    char* temp = urlEncodeString(input.c_str());
+    if (temp) {
+        output << temp;
+        free(temp);
+        return true;
+    }
+    return false;
+}
+
+void EncodeString(const std::string& key, const std::string& value, std::stringstream& output, const std::string& appender = "") {
+    if (!key.empty()) {
+        output << key;
+        if (!value.empty()) {
+            urlencodingInterface(value, output);
+        }
+        if (!appender.empty()) {
+            output << appender;
+        }
+    }
+}
+
 std::stringstream RuntimeFeatureControlProcessor::CreateXconfHTTPUrl() 
 {
     std::stringstream url;
@@ -1497,8 +1519,34 @@ std::stringstream RuntimeFeatureControlProcessor::CreateXconfHTTPUrl()
     url << "accountId=" << _accountId << "&";
     url << "Experience=" << _experience << "&";
     url << "version=" << 2;
+    
+    #ifndef URLENCODING_DISABLED
+    std::stringstream encodedUrl;
+    encodedUrl << _xconf_server_url << "?";
 
-    return url;
+    // Append parameters directly without using a lambda function
+    EncodeString("estbMacAddress=", _estb_mac_address, encodedUrl, "&");
+    EncodeString("firmwareVersion=", _firmware_version, encodedUrl, "&");
+    EncodeString("env=", _build_type_str, encodedUrl, "&");
+    EncodeString("model=", _model_number, encodedUrl, "&");
+    EncodeString("manufacturer=", _manufacturer, encodedUrl, "&");
+
+    encodedUrl << RFC_VIDEO_CONTROL_ID << "&";
+    encodedUrl << RFC_CHANNEL_MAP_ID << "&";
+    encodedUrl << RFC_VIDEO_VOD_ID << "&";
+
+    EncodeString("partnerId=", _partner_id, encodedUrl, "&");
+    EncodeString("osClass=", _osclass, encodedUrl, "&");
+    EncodeString("accountId=", _accountId, encodedUrl, "&");
+    EncodeString("Experience=", _experience, encodedUrl, "&");
+    encodedUrl << "version=2";
+
+    RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] Encoding is enabled plain URL: %s\n", __FUNCTION__, __LINE__, encodedUrl.str().c_str());
+    
+    return encodedUrl; // Use encoded URL
+    #endif
+    
+    return url; // Return encoded URL by default
 }
 
 void RuntimeFeatureControlProcessor::GetStoredHashAndTime( std ::string &valueHash, std::string &valueTime ) 
@@ -1873,7 +1921,7 @@ void RuntimeFeatureControlProcessor::GetValidPartnerId()
 {
     /* Get Valid Partner ID*/
 
-    std::string value = _RFCKeyAndValueMap[RFC_PARNER_ID_KEY_STR];
+    std::string value = _RFCKeyAndValueMap[RFC_PARTNER_ID_KEY_STR];
 
     if(value.empty())
     {

--- a/test/functional-tests/features/rfc_xconf_communication.feature
+++ b/test/functional-tests/features/rfc_xconf_communication.feature
@@ -30,4 +30,7 @@ Feature: RFC Manager XCONF Communication and Error Handling
     When the RFC manager binary is run
     Then an error message "cURL Return : 0 HTTP Code : 404" should be logged
 
-
+  Scenario: URL Encoding
+    Given all the properties to run RFC manager is available and running
+    When RFC manager binary is communicating with XCONF server
+    Then the URL should be percentage encoded 

--- a/test/functional-tests/tests/rfc_test_helper.py
+++ b/test/functional-tests/tests/rfc_test_helper.py
@@ -149,6 +149,19 @@ def grep_log_file(log_file: str, search_string: str) -> bool:
         print(f"An error occurred while running grep: {e}")
         return False
 
+def search_log_file(log_file: str, search_string: str) -> str:
+    result = subprocess.run(
+            f'grep -r "{search_string}" {log_file}*',
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if result.returncode == 0:
+            return result.stdout
+        else :
+            return result.stderr
+
 
 def rfc_run_binary() -> None:
     """

--- a/test/functional-tests/tests/test_rfc_xconf_communication.py
+++ b/test/functional-tests/tests/test_rfc_xconf_communication.py
@@ -19,6 +19,8 @@
 
 import os
 from rfc_test_helper import *
+import urllib.parse
+
 
 
 def get_rfc_old_FW() -> str | None:
@@ -165,11 +167,23 @@ def test_rfcMgr_xconf_communication() -> None:
         post_rfc_run_rfc_version = get_rfc_old_FW()
         rfc_key1, rfc_value1 = get_tr181_file_key_value()
         ERROR_MSG1 = f"COMPLETED RFC PASS"
-
+        
         assert grep_log_file(RFC_LOG_FILE, ERROR_MSG1), f"Expected '{ERROR_MSG1}' in log file."
         assert (post_rfc_run_tr181_File != pre_rfc_run_tr181_File), f"'{TR181_INI_FILE}' creation success on rfc run."
         assert (pre_rfc_run_rfc_version != post_rfc_run_rfc_version) and (device_fw_version == post_rfc_run_rfc_version), f"'{device_fw_version}' updated in '{TR181_INI_FILE}'"
         assert (rfc_key1 == TEST_RFC_PARAM_KEY1) and (rfc_value1 == TEST_RFC_PARAM_VAL1), f"'{TEST_RFC_PARAM_KEY1}' key is set with '{TEST_RFC_PARAM_VAL1} in {TR181_INI_FILE}'"
+
+        SEARCH_MSG = f"Encoding is enabled plain URL: "
+        plain_url = search_log_file(RFC_LOG_FILE,SEARCH_MSG)
+        SEARCH_MSG_ENCODED = f"Xconf Request : "
+        encoded_url = search_log_file(RFC_LOG_FILE,SEARCH_MSG_ENCODED)
+        try:
+            url = plain_url.split(SEARCH_MSG,1)[1]
+            coded_url = encoded_url.split(SEARCH_MSG_ENCODED,1)[1]
+            decoded_url = urllib.parse.unquote(coded_url)
+            assert coded_url == decoded_url
+
+
 
     finally:
         if os.path.exists(RFC_OLD_FW_FILE + "_bak"):


### PR DESCRIPTION
Reason for change: Xconf communication should be using url-encoding for query params to avoid errors
Test Procedure: Xconf communication should be success
Risks: Low