### PR TITLE
RDKB-61479: Successive RFC fetches are returning 200 response instead of 304

### DIFF
--- a/rfcMgr/rfc_xconf_handler.cpp
+++ b/rfcMgr/rfc_xconf_handler.cpp
@@ -1692,9 +1692,11 @@ void RuntimeFeatureControlProcessor::GetStoredHashAndTime( std ::string &valueHa
 {
     if(!_last_firmware.compare( _firmware_version ))
     {
+	RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] Last Image version %s and current image version %s are same \n", __FUNCTION__, __LINE__, _last_firmware.c_str(), _firmware_version.c_str());
         /*Both the input strings are equal.*/
-        if((rfc_state == Init) && (isXconfSelectorSlotProd() == true))
+        if((rfc_state == Init) && (isXconfSelectorSlotProd() == false))
         {
+	    RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] Received XconfSelector as Non Prod for RFC state as INIT \n", __FUNCTION__, __LINE__);
             valueTime = "0";
             valueHash = "OVERRIDE_HASH";
         }
@@ -1705,13 +1707,15 @@ void RuntimeFeatureControlProcessor::GetStoredHashAndTime( std ::string &valueHa
     }
     else
     {
+	RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d] Last Image version %s and current image version %s are different \n", __FUNCTION__, __LINE__, _last_firmware.c_str(), _firmware_version.c_str());
         valueTime = "0";
         valueHash = "UPGRADE_HASH";
     }
 
-    std::string InvalidStr = "Unkown";
+    std::string InvalidStr = "Unknown";
     if ((!_partner_id.compare(InvalidStr)) || (!_accountId.compare(InvalidStr)))
     {
+	RDK_LOG(RDK_LOG_DEBUG, LOG_RFCMGR, "[%s][%d]  Invalid partner or account as Unknown, Passing OVERRIDE_HASH \n", __FUNCTION__, __LINE__);
         valueHash="OVERRIDE_HASH";
     }
 


### PR DESCRIPTION
Passing the check for Xconfselector as Non Prod image to override hash