### PR TITLE
RDKB-61478: Use nvram for debug.ini configuration

### DIFF
--- a/rfcMgr/rfc_manager.cpp
+++ b/rfcMgr/rfc_manager.cpp
@@ -40,7 +40,7 @@ namespace rfc {
 #endif
     RFCManager ::RFCManager() {
         /* Initialize RDK Logger */
-        rdk_logger_init(0 == access("/opt/debug.ini", R_OK) ? "/opt/debug.ini" : "/etc/debug.ini");
+        rdk_logger_init(0 == access(OVERIDE_DEBUG_INI_FILE, R_OK) ? OVERIDE_DEBUG_INI_FILE : DEBUG_INI_FILE);	    
 
         /* Initialize IARM Bus */
         InitializeIARM();

--- a/rfcMgr/rfc_manager.h
+++ b/rfcMgr/rfc_manager.h
@@ -35,6 +35,11 @@
 /*                                   Macros                                   */
 /*----------------------------------------------------------------------------*/
 #define DEBUG_INI_FILE "/etc/debug.ini"
+#if !defined(RDKB_SUPPORT)
+#define OVERIDE_DEBUG_INI_FILE "/opt/debug.ini"
+#else
+#define OVERIDE_DEBUG_INI_FILE "/nvram/debug.ini"
+#endif
 #define DNS_RESOLV_FILE "/etc/resolv.dnsmasq"
 #define IP_ROUTE_FLAG "/tmp/route_available"
 #define GATEWAYIP_FILE "/tmp/.GatewayIP_dfltroute"


### PR DESCRIPTION
Added changes to use macro for debug.ini file on RDKB and RDKV