### PR TITLE
RDKEMW-9437 : Secure Unlock of Debug services(overrides) in LabSigned Build type

### DIFF
--- a/rfcMgr/rfc_xconf_handler.cpp
+++ b/rfcMgr/rfc_xconf_handler.cpp
@@ -162,7 +162,7 @@ bool RuntimeFeatureControlProcessor::GetDbgBuildValue(char *pBuf, size_t szBufSi
     }
 
     while (fgets(buf, sizeof(buf), fp)) {
-        if (strncmp(buf, key, sizeof(key)-1 ) == 0) {
+        if (strncmp(buf, key, strlen(key)) == 0) {
             eVal = strchr(buf, '=');
             if (eVal) {
                 ++eVal;
@@ -192,7 +192,7 @@ bool RuntimeFeatureControlProcessor::GetDbgBuildValue(char *pBuf, size_t szBufSi
         *eBuf = tolower((unsigned char)*eBuf);
         ++eBuf;
     }
-    if (strstr(firmware, "DbgBuild_ProdHw") && strstr(pBuf, "true"))
+    if (strstr(firmware, "dbgbuild_prodhw") && strstr(pBuf, "true"))
         isEnabled = true;
     return isEnabled;
 }

--- a/rfcMgr/rfc_xconf_handler.cpp
+++ b/rfcMgr/rfc_xconf_handler.cpp
@@ -46,7 +46,7 @@ extern "C" {
 #define MTLS_FAILURE -1
 #endif
 
-static inline bool RuntimeFeatureControlProcessor:: Debug_Services_Enabled(bool labSigned, BUILDTYPE eBuildType, bool dbgServices, eDeviceType deviceType) { 
+inline bool RuntimeFeatureControlProcessor:: Debug_Services_Enabled(bool labSigned, BUILDTYPE eBuildType, bool dbgServices, eDeviceType deviceType) { 
      return (labSigned && (eBuildType == ePROD) && dbgServices && (deviceType == DEVICE_TYPE_TEST)) || (eBuildType == eDEV));
 }
 

--- a/rfcMgr/rfc_xconf_handler.cpp
+++ b/rfcMgr/rfc_xconf_handler.cpp
@@ -47,7 +47,7 @@ extern "C" {
 #endif
 
 inline bool RuntimeFeatureControlProcessor:: Debug_Services_Enabled(bool labSigned, BUILDTYPE eBuildType, bool dbgServices, eDeviceType deviceType) { 
-     return (labSigned && (eBuildType == ePROD) && dbgServices && (deviceType == DEVICE_TYPE_TEST)) || (eBuildType == eDEV));
+     return (labSigned && (eBuildType == ePROD) && dbgServices && (deviceType == DEVICE_TYPE_TEST)) || (eBuildType == eDEV);
 }
 
 int RuntimeFeatureControlProcessor:: InitializeRuntimeFeatureControlProcessor(void)
@@ -1556,7 +1556,7 @@ int RuntimeFeatureControlProcessor::ProcessRuntimeFeatureControlReq()
     int retries = 0;
 	int sleep_time = 0;
 	char buf[URL_MAX_LEN];
-	bool labSigned = GetLabsignedValue(buf2, sizeof(buf2));
+	bool labSigned = GetLabsignedValue(buf, sizeof(buf));
 	eDeviceType deviceType = getDeviceType();
     /* Check if New Firmware Request*/
 
@@ -1570,7 +1570,7 @@ int RuntimeFeatureControlProcessor::ProcessRuntimeFeatureControlReq()
     {
         while(retries < RETRY_COUNT)
         {
-            if((filePresentCheck(RFC_PROPERTIES_PERSISTENCE_FILE) == RDK_API_SUCCESS) && (Debug_Services_Enabled(labSigned, _ebuild_type, dbgServices, deviceType))
+            if((filePresentCheck(RFC_PROPERTIES_PERSISTENCE_FILE) == RDK_API_SUCCESS) && (Debug_Services_Enabled(labSigned, _ebuild_type, dbgServices, deviceType)))
             {
                 RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR, "[%s][%d] Setting URL from local override to %s\n", __FUNCTION__, __LINE__, _xconf_server_url.c_str());
                 NotifyTelemetry2Value("SYST_INFO_RFC_XconflocalURL", _xconf_server_url.c_str());

--- a/rfcMgr/rfc_xconf_handler.cpp
+++ b/rfcMgr/rfc_xconf_handler.cpp
@@ -69,7 +69,7 @@ int RuntimeFeatureControlProcessor:: InitializeRuntimeFeatureControlProcessor(vo
     
     GetRFCPartnerID();
 
-    if((filePresentCheck(RFC_PROPERTIES_PERSISTENCE_FILE) == RDK_API_SUCCESS) && (Debug_Services_Enabled(labSigned, eBuildType, dbgServices, deviceType)))
+    if((filePresentCheck(RFC_PROPERTIES_PERSISTENCE_FILE) == RDK_API_SUCCESS) && (Debug_Services_Enabled(labSigned, _ebuild_type, dbgServices, deviceType)))
     {
 	rfc_file = RFC_PROPERTIES_PERSISTENCE_FILE;
 	rfc_state = Local;
@@ -1570,7 +1570,7 @@ int RuntimeFeatureControlProcessor::ProcessRuntimeFeatureControlReq()
     {
         while(retries < RETRY_COUNT)
         {
-            if((filePresentCheck(RFC_PROPERTIES_PERSISTENCE_FILE) == RDK_API_SUCCESS) && (Debug_Services_Enabled(labSigned, eBuildType, dbgServices, deviceType))
+            if((filePresentCheck(RFC_PROPERTIES_PERSISTENCE_FILE) == RDK_API_SUCCESS) && (Debug_Services_Enabled(labSigned, _ebuild_type, dbgServices, deviceType))
             {
                 RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR, "[%s][%d] Setting URL from local override to %s\n", __FUNCTION__, __LINE__, _xconf_server_url.c_str());
                 NotifyTelemetry2Value("SYST_INFO_RFC_XconflocalURL", _xconf_server_url.c_str());

--- a/rfcMgr/rfc_xconf_handler.cpp
+++ b/rfcMgr/rfc_xconf_handler.cpp
@@ -46,7 +46,7 @@ extern "C" {
 #define MTLS_FAILURE -1
 #endif
 
-inline bool RuntimeFeatureControlProcessor:: Debug_Services_Enabled(bool DbgBuild, BUILDTYPE eBuildType, bool dbgServices, eDeviceType deviceType) { 
+bool RuntimeFeatureControlProcessor:: Debug_Services_Enabled(bool DbgBuild, BUILDTYPE eBuildType, bool dbgServices, eDeviceType deviceType) { 
      return (DbgBuild && (eBuildType == ePROD) && dbgServices && (deviceType == DEVICE_TYPE_TEST)) || (eBuildType == eDEV);
 }
 

--- a/rfcMgr/rfc_xconf_handler.cpp
+++ b/rfcMgr/rfc_xconf_handler.cpp
@@ -51,7 +51,8 @@ bool RuntimeFeatureControlProcessor:: enableDebugServices(void) {
 	eDeviceType deviceType = getDeviceTypeRFC(); //Check if device type is TEST from RFC
 	bool isDebugServicesUnlocked = false;// return value
 	const char* key = "LABSIGNED_ENABLED="; // key from /etc/device.properties
-	char pBuf[URL_MAX_LEN];
+	char buf[150] = {0};
+	char pBuf[URL_MAX_LEN] = {0};
 	char *eVal = NULL;
 	char *eBuf = NULL;
 	int i = 0;

--- a/rfcMgr/rfc_xconf_handler.cpp
+++ b/rfcMgr/rfc_xconf_handler.cpp
@@ -51,7 +51,6 @@ bool RuntimeFeatureControlProcessor:: enableDebugServices(void) {
 	eDeviceType deviceType = getDeviceTypeRFC(); //Check if device type is TEST from RFC
 	bool isDebugServicesUnlocked = false;// return value
 	const char* key = "LABSIGNED_ENABLED="; // key from /etc/device.properties
-	FILE *fp = fopen(DEVICE_PROPERTIES_FILE, "r");
 	char pBuf[URL_MAX_LEN];
 	char *eVal = NULL;
 	char *eBuf = NULL;
@@ -61,6 +60,7 @@ bool RuntimeFeatureControlProcessor:: enableDebugServices(void) {
 		isDebugServicesUnlocked = true;
 	else if (_ebuild_type == ePROD){
 	    //Read LABSIGNED_ENABLED value from /etc/device.properties
+	    FILE *fp = fopen(DEVICE_PROPERTIES_FILE, "r");
 	    if (!fp) {
 			RDK_LOG(RDK_LOG_ERROR, LOG_RFCMGR, "[%s][%d] Failed to open %s file.\n", __FUNCTION__, __LINE__, DEVICE_PROPERTIES_FILE);
             return isDebugServicesUnlocked;

--- a/rfcMgr/rfc_xconf_handler.cpp
+++ b/rfcMgr/rfc_xconf_handler.cpp
@@ -46,10 +46,17 @@ extern "C" {
 #define MTLS_FAILURE -1
 #endif
 
+static inline bool RuntimeFeatureControlProcessor:: Debug_Services_Enabled(bool labSigned, BUILDTYPE eBuildType, bool dbgServices, eDeviceType deviceType) { 
+     return (labSigned && (eBuildType == ePROD) && dbgServices && (deviceType == DEVICE_TYPE_TEST)) || (eBuildType == eDEV));
+}
+
 int RuntimeFeatureControlProcessor:: InitializeRuntimeFeatureControlProcessor(void)
 {
      std::string rfc_file;
      bool dbgServices = isDebugServicesEnabled();
+	 char buf[URL_MAX_LEN];
+	 bool labSigned = GetLabsignedValue(buf, sizeof(buf));
+	 eDeviceType deviceType = getDeviceType();
 	
     int rc = GetBootstrapXconfUrl(_boot_strap_xconf_url);
     if(rc != 0)
@@ -62,7 +69,7 @@ int RuntimeFeatureControlProcessor:: InitializeRuntimeFeatureControlProcessor(vo
     
     GetRFCPartnerID();
 
-    if((filePresentCheck(RFC_PROPERTIES_PERSISTENCE_FILE) == RDK_API_SUCCESS) && (_ebuild_type != ePROD || dbgServices == true))
+    if((filePresentCheck(RFC_PROPERTIES_PERSISTENCE_FILE) == RDK_API_SUCCESS) && (Debug_Services_Enabled(labSigned, eBuildType, dbgServices, deviceType)))
     {
 	rfc_file = RFC_PROPERTIES_PERSISTENCE_FILE;
 	rfc_state = Local;
@@ -115,7 +122,80 @@ int RuntimeFeatureControlProcessor:: InitializeRuntimeFeatureControlProcessor(vo
     return SUCCESS;
 }
 
+eDeviceType RuntimeFeatureControlProcessor:: getDeviceType(void) {
+    char rfc_data[RFC_VALUE_BUF_SIZE] = {0};
+    int ret = read_RFCProperty("LABSGND", RFC_DEVICETYPE, rfc_data, sizeof(rfc_data));
 
+    if (ret == -1) {
+        SWLOG_ERROR("%s: Failed to read device type\n", __FUNCTION__);
+		RDK_LOG(RDK_LOG_ERROR, LOG_RFCMGR, "[%s][%d] rfc device type =%s failed Status %d\n", __FUNCTION__, __LINE__, RFC_DEVICETYPE, ret);
+        return DEVICE_TYPE_UNKNOWN;
+    }
+	RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR, "[%s][%d] rfc device type = %s\n", __FUNCTION__, __LINE__, rfc_data);
+    if (strncasecmp(rfc_data, "prod", 4) == 0) {
+        return DEVICE_TYPE_PROD;
+    } else if (strncasecmp(rfc_data, "test", 4) == 0) {
+        return DEVICE_TYPE_TEST;
+    }
+    return DEVICE_TYPE_UNKNOWN;
+}
+
+bool RuntimeFeatureControlProcessor::GetLabsignedValue(char *pBuf, size_t szBufSize)
+{
+    FILE *fp;
+    bool isEnabled = false;
+    char buf[150] = {0};
+    char firmware[150] = {0};
+    char *eVal, *eBuf;
+    int i = 0;
+	const char* key = "LABSIGNED_ENABLED=";
+
+    if (!pBuf || szBufSize == 0)
+        return false;
+
+    *pBuf = '\0';
+
+    fp = fopen(DEVICE_PROPERTIES_FILE, "r");
+    if (!fp) {
+		RDK_LOG(RDK_LOG_ERROR, LOG_RFCMGR, "[%s][%d] Failed to open /etc/device.properties.\n", __FUNCTION__, __LINE__);
+        return isEnabled;
+    }
+
+    while (fgets(buf, sizeof(buf), fp)) {
+        if (strncmp(buf, key, sizeof(key)-1 ) == 0) {
+            eVal = strchr(buf, '=');
+            if (eVal) {
+                ++eVal;
+                i = snprintf(pBuf, szBufSize, "%s", eVal);
+                i = stripinvalidchar(pBuf, i);
+                eBuf = pBuf;
+                while (*eBuf) {
+                    *eBuf = tolower((unsigned char)*eBuf);
+                    ++eBuf;
+                }
+            }
+            break;
+        }
+    }
+    fclose(fp);
+    if (*pBuf == '\0') {
+        RDK_LOG(RDK_LOG_ERROR, LOG_RFCMGR, "[%s][%d] Failed to get LABIGNED_ENABLED value from /etc/device.properties.\n", __FUNCTION__, __LINE__);
+        return isEnabled;
+    }
+
+    if (GetFirmwareVersion(firmware, sizeof(firmware)) == 0 || *firmware == '\0') {
+        RDK_LOG(RDK_LOG_ERROR, LOG_RFCMGR, "[%s][%d] Failed to get firmware version value.\n", __FUNCTION__, __LINE__);
+        return isEnabled;
+    }
+    eBuf = firmware;
+    while (*eBuf) {
+        *eBuf = tolower((unsigned char)*eBuf);
+        ++eBuf;
+    }
+    if (strstr(firmware, "labsigned") && strstr(pBuf, "true"))
+        isEnabled = true;
+    return isEnabled;
+}
 
 bool RuntimeFeatureControlProcessor::checkWhoamiSupport()
 {
@@ -1475,6 +1555,9 @@ int RuntimeFeatureControlProcessor::ProcessRuntimeFeatureControlReq()
 {
     int retries = 0;
 	int sleep_time = 0;
+	char buf[URL_MAX_LEN];
+	bool labSigned = GetLabsignedValue(buf2, sizeof(buf2));
+	eDeviceType deviceType = getDeviceType();
     /* Check if New Firmware Request*/
 
     rfcSelectOpt = (rfc_state == Local) ? "local" : "prod";
@@ -1487,7 +1570,7 @@ int RuntimeFeatureControlProcessor::ProcessRuntimeFeatureControlReq()
     {
         while(retries < RETRY_COUNT)
         {
-            if((filePresentCheck(RFC_PROPERTIES_PERSISTENCE_FILE) == RDK_API_SUCCESS) && (_ebuild_type != ePROD || dbgServices == true))
+            if((filePresentCheck(RFC_PROPERTIES_PERSISTENCE_FILE) == RDK_API_SUCCESS) && (Debug_Services_Enabled(labSigned, eBuildType, dbgServices, deviceType))
             {
                 RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR, "[%s][%d] Setting URL from local override to %s\n", __FUNCTION__, __LINE__, _xconf_server_url.c_str());
                 NotifyTelemetry2Value("SYST_INFO_RFC_XconflocalURL", _xconf_server_url.c_str());

--- a/rfcMgr/rfc_xconf_handler.cpp
+++ b/rfcMgr/rfc_xconf_handler.cpp
@@ -46,8 +46,8 @@ extern "C" {
 #define MTLS_FAILURE -1
 #endif
 
-inline bool RuntimeFeatureControlProcessor:: Debug_Services_Enabled(bool labSigned, BUILDTYPE eBuildType, bool dbgServices, eDeviceType deviceType) { 
-     return (labSigned && (eBuildType == ePROD) && dbgServices && (deviceType == DEVICE_TYPE_TEST)) || (eBuildType == eDEV);
+inline bool RuntimeFeatureControlProcessor:: Debug_Services_Enabled(bool DbgBuild, BUILDTYPE eBuildType, bool dbgServices, eDeviceType deviceType) { 
+     return (DbgBuild && (eBuildType == ePROD) && dbgServices && (deviceType == DEVICE_TYPE_TEST)) || (eBuildType == eDEV);
 }
 
 int RuntimeFeatureControlProcessor:: InitializeRuntimeFeatureControlProcessor(void)
@@ -55,7 +55,7 @@ int RuntimeFeatureControlProcessor:: InitializeRuntimeFeatureControlProcessor(vo
      std::string rfc_file;
      bool dbgServices = isDebugServicesEnabled();
 	 char buf[URL_MAX_LEN];
-	 bool labSigned = GetLabsignedValue(buf, sizeof(buf));
+	 bool DbgBuild = GetDbgBuildValue(buf, sizeof(buf));
 	 eDeviceType deviceType = getDeviceType();
 	
     int rc = GetBootstrapXconfUrl(_boot_strap_xconf_url);
@@ -69,7 +69,7 @@ int RuntimeFeatureControlProcessor:: InitializeRuntimeFeatureControlProcessor(vo
     
     GetRFCPartnerID();
 
-    if((filePresentCheck(RFC_PROPERTIES_PERSISTENCE_FILE) == RDK_API_SUCCESS) && (Debug_Services_Enabled(labSigned, _ebuild_type, dbgServices, deviceType)))
+    if((filePresentCheck(RFC_PROPERTIES_PERSISTENCE_FILE) == RDK_API_SUCCESS) && (Debug_Services_Enabled(DbgBuild, _ebuild_type, dbgServices, deviceType)))
     {
 	rfc_file = RFC_PROPERTIES_PERSISTENCE_FILE;
 	rfc_state = Local;
@@ -140,7 +140,7 @@ eDeviceType RuntimeFeatureControlProcessor:: getDeviceType(void) {
     return DEVICE_TYPE_UNKNOWN;
 }
 
-bool RuntimeFeatureControlProcessor::GetLabsignedValue(char *pBuf, size_t szBufSize)
+bool RuntimeFeatureControlProcessor::GetDbgBuildValue(char *pBuf, size_t szBufSize)
 {
     FILE *fp;
     bool isEnabled = false;
@@ -148,7 +148,7 @@ bool RuntimeFeatureControlProcessor::GetLabsignedValue(char *pBuf, size_t szBufS
     char firmware[150] = {0};
     char *eVal, *eBuf;
     int i = 0;
-	const char* key = "LABSIGNED_ENABLED=";
+	const char* key = "DBGBUILD_PRODHW=";
 
     if (!pBuf || szBufSize == 0)
         return false;
@@ -179,7 +179,7 @@ bool RuntimeFeatureControlProcessor::GetLabsignedValue(char *pBuf, size_t szBufS
     }
     fclose(fp);
     if (*pBuf == '\0') {
-        RDK_LOG(RDK_LOG_ERROR, LOG_RFCMGR, "[%s][%d] Failed to get LABIGNED_ENABLED value from /etc/device.properties.\n", __FUNCTION__, __LINE__);
+        RDK_LOG(RDK_LOG_ERROR, LOG_RFCMGR, "[%s][%d] Failed to get DBGBUILD_PRODHW value from /etc/device.properties.\n", __FUNCTION__, __LINE__);
         return isEnabled;
     }
 
@@ -192,7 +192,7 @@ bool RuntimeFeatureControlProcessor::GetLabsignedValue(char *pBuf, size_t szBufS
         *eBuf = tolower((unsigned char)*eBuf);
         ++eBuf;
     }
-    if (strstr(firmware, "labsigned") && strstr(pBuf, "true"))
+    if (strstr(firmware, "DbgBuild_ProdHw") && strstr(pBuf, "true"))
         isEnabled = true;
     return isEnabled;
 }
@@ -1556,7 +1556,7 @@ int RuntimeFeatureControlProcessor::ProcessRuntimeFeatureControlReq()
     int retries = 0;
 	int sleep_time = 0;
 	char buf[URL_MAX_LEN];
-	bool labSigned = GetLabsignedValue(buf, sizeof(buf));
+	bool DbgBuild = GetDbgBuildValue(buf, sizeof(buf));
 	eDeviceType deviceType = getDeviceType();
     /* Check if New Firmware Request*/
 
@@ -1570,7 +1570,7 @@ int RuntimeFeatureControlProcessor::ProcessRuntimeFeatureControlReq()
     {
         while(retries < RETRY_COUNT)
         {
-            if((filePresentCheck(RFC_PROPERTIES_PERSISTENCE_FILE) == RDK_API_SUCCESS) && (Debug_Services_Enabled(labSigned, _ebuild_type, dbgServices, deviceType)))
+            if((filePresentCheck(RFC_PROPERTIES_PERSISTENCE_FILE) == RDK_API_SUCCESS) && (Debug_Services_Enabled(DbgBuild, _ebuild_type, dbgServices, deviceType)))
             {
                 RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR, "[%s][%d] Setting URL from local override to %s\n", __FUNCTION__, __LINE__, _xconf_server_url.c_str());
                 NotifyTelemetry2Value("SYST_INFO_RFC_XconflocalURL", _xconf_server_url.c_str());

--- a/rfcMgr/rfc_xconf_handler.cpp
+++ b/rfcMgr/rfc_xconf_handler.cpp
@@ -68,12 +68,21 @@ bool RuntimeFeatureControlProcessor::isSecureDbgSrvUnlocked(void) {
         while (fgets(buf, sizeof(buf), fp)) {
             if (strncmp(buf, key, strlen(key)) == 0) {
                 char *eVal = buf + strlen(key);  // points to value after '='
-                if (strcasecmp(eVal, "true") == 0) {
+				char pBuf[URL_MAX_LEN] = {0};
+                snprintf(pBuf, sizeof(pBuf), "%s", eVal);
+                stripinvalidchar(pBuf, strlen(pBuf));
+                if (strcasecmp(pBuf, "true") == 0) {
                     if ((deviceType == DEVICE_TYPE_TEST) && dbgServices) {
                         RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR, 
                                 "[%s][%d] Enabling Debug Services\n", __FUNCTION__, __LINE__);
                         isDebugServicesUnlocked = true;
                     }
+					else{
+						RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR, 
+                                "[%s][%d] unable to enable Debug Services\n", __FUNCTION__, __LINE__);
+						RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR, 
+                                "[%s][%d] dbgServices=%s, deviceType=%d, LABSIGNED_ENABLED=%s\n", __FUNCTION__, __LINE__,dbgServices ? "true" : "false", deviceType, pBuf);
+					}
                 }
                 break;
             }

--- a/rfcMgr/rfc_xconf_handler.h
+++ b/rfcMgr/rfc_xconf_handler.h
@@ -209,8 +209,8 @@ class RuntimeFeatureControlProcessor : public xconf::XconfHandler
         int ProcessXconfUrl(const char *XconfUrl);
 	bool isDebugServicesEnabled(void);
     eDeviceType getDeviceType(void);
-    bool GetDbgBuildValue(char *pBuf, size_t szBufSize);
-    bool Debug_Services_Enabled(bool DbgBuild, BUILDTYPE eBuildType, bool dbgServices, eDeviceType deviceType);
+    bool isLabSignedEnabled(char *pBuf, size_t szBufSize);
+    bool Debug_Services_Enabled(bool isLabSigned, BUILDTYPE eBuildType, bool dbgServices, eDeviceType deviceType);
 
 #if defined(GTEST_ENABLE)
     FRIEND_TEST(rfcMgrTest, isNewFirmwareFirstRequest);

--- a/rfcMgr/rfc_xconf_handler.h
+++ b/rfcMgr/rfc_xconf_handler.h
@@ -209,8 +209,8 @@ class RuntimeFeatureControlProcessor : public xconf::XconfHandler
         int ProcessXconfUrl(const char *XconfUrl);
 	bool isDebugServicesEnabled(void);
     eDeviceType getDeviceType(void);
-    bool GetLabsignedValue(char *pBuf, size_t szBufSize);
-    static inline bool Debug_Services_Enabled(bool labSigned, BUILDTYPE eBuildType, bool dbgServices, eDeviceType deviceType);
+    bool GetDbgBuildValue(char *pBuf, size_t szBufSize);
+    static inline bool Debug_Services_Enabled(bool DbgBuild, BUILDTYPE eBuildType, bool dbgServices, eDeviceType deviceType);
 
 #if defined(GTEST_ENABLE)
     FRIEND_TEST(rfcMgrTest, isNewFirmwareFirstRequest);

--- a/rfcMgr/rfc_xconf_handler.h
+++ b/rfcMgr/rfc_xconf_handler.h
@@ -208,9 +208,8 @@ class RuntimeFeatureControlProcessor : public xconf::XconfHandler
 	void cleanAllFile();
         int ProcessXconfUrl(const char *XconfUrl);
 	bool isDebugServicesEnabled(void);
-    eDeviceType getDeviceType(void);
-    bool isLabSignedEnabled(char *pBuf, size_t szBufSize);
-    bool Debug_Services_Enabled(bool isLabSigned, BUILDTYPE eBuildType, bool dbgServices, eDeviceType deviceType);
+    eDeviceType getDeviceTypeRFC(void);
+    bool enableDebugServices(void);
 
 #if defined(GTEST_ENABLE)
     FRIEND_TEST(rfcMgrTest, isNewFirmwareFirstRequest);

--- a/rfcMgr/rfc_xconf_handler.h
+++ b/rfcMgr/rfc_xconf_handler.h
@@ -210,7 +210,7 @@ class RuntimeFeatureControlProcessor : public xconf::XconfHandler
 	bool isDebugServicesEnabled(void);
     eDeviceType getDeviceType(void);
     bool GetDbgBuildValue(char *pBuf, size_t szBufSize);
-    static inline bool Debug_Services_Enabled(bool DbgBuild, BUILDTYPE eBuildType, bool dbgServices, eDeviceType deviceType);
+    bool Debug_Services_Enabled(bool DbgBuild, BUILDTYPE eBuildType, bool dbgServices, eDeviceType deviceType);
 
 #if defined(GTEST_ENABLE)
     FRIEND_TEST(rfcMgrTest, isNewFirmwareFirstRequest);

--- a/rfcMgr/rfc_xconf_handler.h
+++ b/rfcMgr/rfc_xconf_handler.h
@@ -209,7 +209,7 @@ class RuntimeFeatureControlProcessor : public xconf::XconfHandler
         int ProcessXconfUrl(const char *XconfUrl);
 	bool isDebugServicesEnabled(void);
     eDeviceType getDeviceTypeRFC(void);
-    bool enableDebugServices(void);
+    bool isSecureDbgSrvUnlocked(void);
 
 #if defined(GTEST_ENABLE)
     FRIEND_TEST(rfcMgrTest, isNewFirmwareFirstRequest);

--- a/rfcMgr/rfc_xconf_handler.h
+++ b/rfcMgr/rfc_xconf_handler.h
@@ -67,11 +67,13 @@ extern "C" {
 #define TR181STOREFILE                      "/opt/secure/RFC/tr181store.ini" 
 #define DIRECT_BLOCK_FILENAME              "/tmp/.lastdirectfail_rfc"
 #define RFC_DEBUGSRV                       "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Identity.DbgServices.Enable"
+#define RFC_DEVICETYPE                     "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Identity.DeviceType"
 
 #define RFC_VIDEO_CONTROL_ID               2504
 #define RFC_VIDEO_VOD_ID                   15660
 #define RFC_CHANNEL_MAP_ID                 2345
 #define RETRY_DELAY                        10
+#define URL_MAX_LEN                        512
 
 #define RFC_SYNC_DONE                      "/tmp/.rfcSyncDone"
 
@@ -91,6 +93,12 @@ typedef enum {
     WDMP_FAILURE,
 } WDMP_STATUS;
 #endif
+
+typedef enum {
+    DEVICE_TYPE_UNKNOWN = 0,
+    DEVICE_TYPE_PROD,
+    DEVICE_TYPE_TEST
+} eDeviceType;
 
 class RuntimeFeatureControlProcessor : public xconf::XconfHandler
 {
@@ -200,6 +208,9 @@ class RuntimeFeatureControlProcessor : public xconf::XconfHandler
 	void cleanAllFile();
         int ProcessXconfUrl(const char *XconfUrl);
 	bool isDebugServicesEnabled(void);
+    eDeviceType getDeviceType(void);
+    bool GetLabsignedValue(char *pBuf, size_t szBufSize);
+    static inline bool Debug_Services_Enabled(bool labSigned, BUILDTYPE eBuildType, bool dbgServices, eDeviceType deviceType);
 
 #if defined(GTEST_ENABLE)
     FRIEND_TEST(rfcMgrTest, isNewFirmwareFirstRequest);


### PR DESCRIPTION
Reason for change: Integrating rfc debug services changes with new labsigned build variant and additional checks
Test Procedure: Set debug services and verify
Risks: Low
Priority: P1