### PR TITLE
RDKEMW-12202 : Post activation, Device failed to get telemetry url RFC

### DIFF
--- a/rfcMgr/rfc_xconf_handler.cpp
+++ b/rfcMgr/rfc_xconf_handler.cpp
@@ -2413,7 +2413,7 @@ void RuntimeFeatureControlProcessor::processXconfResponseConfigDataPart(JSON *fe
         }
         else
         {
-            if (currentValue.empty())
+            if (newValue.empty())
             {
 	        RDK_LOG(RDK_LOG_INFO, LOG_RFCMGR, "[%s][%d] EMPTY value for %s is rejected\n", __FUNCTION__, __LINE__, newKey.c_str());
                 continue;


### PR DESCRIPTION
RDKEMW-12202: Update rfc_xconf_handler.cpp to check for newvalue is empty instead of currentvalue as FSR case all currentvalue will be empty