### PR TITLE
RDKC-15902: Fix reboot loop by skipping clearDB on RDKC

### DIFF
--- a/rfcMgr/rfc_xconf_handler.cpp
+++ b/rfcMgr/rfc_xconf_handler.cpp
@@ -2488,7 +2488,7 @@ void RuntimeFeatureControlProcessor::processXconfResponseConfigDataPart(JSON *fe
         RDK_LOG(RDK_LOG_ERROR, LOG_RFCMGR, "[%s][%d] Config Data Map is Empty\n", __FUNCTION__, __LINE__);
         return;    
     }
-#if !defined(RDKB_SUPPORT)
+#if !defined(RDKB_SUPPORT) && !defined(RDKC)
     clearDB();
 #endif    
 


### PR DESCRIPTION
Calling clearDB()
unconditionally, which deletes tr181store.ini. The rbus provider reads
from this file, so after deletion rbus_get returns empty/default values,
making all params appear changed on every run - causing an infinite
reboot loop.

Fix: Skip clearDB() for RDKC as well