### PR TITLE
RDKC-15902: Add RDKC model number retrieval via vendor api

### DIFF
--- a/rfcMgr/xconf_handler.cpp
+++ b/rfcMgr/xconf_handler.cpp
@@ -100,7 +100,18 @@ int XconfHandler:: initializeXconfHandler()
 	}
 	
 	memset(tmpbuf, '\0', sizeof(tmpbuf));
+#ifdef RDKC
+	{
+	    std::string model = getModelNumber();
+	    if (!model.empty()) {
+	        strncpy(tmpbuf, model.c_str(), sizeof(tmpbuf) - 1);
+	        tmpbuf[sizeof(tmpbuf) - 1] = '\0';
+	        len = strlen(tmpbuf);
+	    }
+	}
+#else
 	len = GetModelNum( tmpbuf, sizeof(tmpbuf) );
+#endif
         if( len )
         {
 	     _model_number = tmpbuf;


### PR DESCRIPTION
Use Vendor api mfrApi_test via getModelNumber() for RDKC instead of GetModelNum() from common_device_api
As using common api i.e. reading model_num from device properties file is getting wrong model and causing regression